### PR TITLE
fix: conform input schema to JSON Schema draft 2020-12

### DIFF
--- a/click_mcp/scanner.py
+++ b/click_mcp/scanner.py
@@ -263,19 +263,21 @@ def _get_parameter_info(param: click.Parameter) -> Optional[Dict[str, Any]]:
     elif isinstance(param.type, click.types.BoolParamType):
         param_type = "boolean"
 
-    # Create schema object
-    schema: Dict[str, Any] = {"type": param_type}
+    # Create parameter info (this represents the schema for a single property)
+    # According to JSON Schema draft 2020-12, properties should have type directly
+    param_data: Dict[str, Any] = {
+        "type": param_type,
+    }
+
+    # Add description if available
+    help_text = getattr(param, "help", "")
+    if help_text:
+        param_data["description"] = help_text
 
     # Handle choices if present
     if hasattr(param, "choices") and param.choices is not None:
         if isinstance(param.choices, (list, tuple)):
-            schema["enum"] = list(param.choices)
-
-    # Create parameter info (this represents the schema for a single property)
-    param_data = {
-        "description": getattr(param, "help", ""),
-        "schema": schema,
-    }
+            param_data["enum"] = list(param.choices)
 
     # Add default if available and not callable
     default = getattr(param, "default", None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -103,7 +103,7 @@ async def test_basic_server_tools(basic_mcp_session):
     assert echo_tool.inputSchema["type"] == "object"
     assert "properties" in echo_tool.inputSchema
     assert "count" in echo_tool.inputSchema["properties"]
-    assert echo_tool.inputSchema["properties"]["count"]["schema"]["type"] == "integer"
+    assert echo_tool.inputSchema["properties"]["count"]["type"] == "integer"
     assert "message" in echo_tool.inputSchema["properties"]
     assert "required" in echo_tool.inputSchema
     assert "message" in echo_tool.inputSchema["required"]  # Only message is required
@@ -273,7 +273,7 @@ async def test_advanced_server_tools(advanced_mcp_session):
     assert "properties" in greet_tool.inputSchema
     assert "name" in greet_tool.inputSchema["properties"]
     assert "formal" in greet_tool.inputSchema["properties"]
-    assert greet_tool.inputSchema["properties"]["formal"]["schema"]["type"] == "boolean"
+    assert greet_tool.inputSchema["properties"]["formal"]["type"] == "boolean"
     assert "required" in greet_tool.inputSchema
     assert "name" in greet_tool.inputSchema["required"]  # Only name is required
 


### PR DESCRIPTION
The generated tool input schemas were invalid according to JSON Schema draft 2020-12 specification. The issue was that parameter properties were wrapped in a nested "schema" field instead of having the type directly in the property definition.

Changes:
- Remove invalid nested "schema" field from parameter properties
- Add "type" directly to parameter properties (conforming to spec)
- Only include "description" field when help text is non-empty
- Preserve support for "enum", "default", and other valid fields

Before (invalid):
{
  "properties": { "param": { "description": null, "schema": { "type": "boolean" } } } }

After (valid):
{
  "properties": { "param": { "type": "boolean" } } }

This fixes API errors when using click-mcp tools with Claude API: "tools.X.custom.input_schema: JSON schema is invalid"