### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -45,7 +46,7 @@ Issues = "https://github.com/crowecawcaw/click-mcp/issues"
 packages = ["click_mcp"]
 
 [tool.black]
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 line-length = 88
 
 [tool.ruff]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
## Summary
This PR adds support for Python 3.14 across the project configuration and CI/CD pipeline.

## Key Changes
- Added Python 3.14 to the package classifiers in `pyproject.toml` and `setup.py`
- Updated Black's target version configuration to include Python 3.14
- Extended the GitHub Actions test matrix to run tests against Python 3.14

## Details
These changes ensure that:
1. The package is properly advertised as supporting Python 3.14 on PyPI
2. Code formatting with Black targets Python 3.14 syntax compatibility
3. Automated tests run against Python 3.14 to verify compatibility

https://claude.ai/code/session_01PNLTSRqfS7kN3bYJJF2nRS